### PR TITLE
Commit para corrigir a rolagem horizontal.

### DIFF
--- a/comparador/static/style.css
+++ b/comparador/static/style.css
@@ -46,3 +46,15 @@ button:hover {
   overflow-x: auto;
   margin-top: 20px;
 }
+
+.resultado-diff {
+    max-height: 500px;       /* Altura máxima visível */
+    overflow-y: auto;        /* Rolagem vertical */
+    overflow-x: hidden;      /* Remove rolagem horizontal */
+}
+/* Faz as células quebrarem linhas longas */
+table.diff td {
+    white-space: pre-wrap;   /* Mantém espaços e quebra linhas */
+    word-break: break-word;  /* Quebra palavras grandes */
+    max-width: 400px;        /* Largura máxima para a célula */
+}


### PR DESCRIPTION
O HtmlDiff estava gerando uma tabela grande para exibir lado a lado as comparações, e como os textos longos estavam quebrando só no fim da linha, o navegador criava uma rolagem horizontal.

Usei .CSS pra concertar esse pequeno erro, assim ficou mais fácil para ler os texto grandes lado a lado e poder ver as semelhanças/diferenças.