### PR TITLE
Commit para correção de rolagem horizontal.

### DIFF
--- a/comparador/static/style.css
+++ b/comparador/static/style.css
@@ -47,14 +47,16 @@ button:hover {
   margin-top: 20px;
 }
 
+/* Concerta a rolagem vertical */
 .resultado-diff {
-    max-height: 500px;       /* Altura máxima visível */
-    overflow-y: auto;        /* Rolagem vertical */
-    overflow-x: hidden;      /* Remove rolagem horizontal */
+    max-height: 500px;
+    overflow-y: auto; 
+    overflow-x: hidden;
 }
+
 /* Faz as células quebrarem linhas longas */
 table.diff td {
-    white-space: pre-wrap;   /* Mantém espaços e quebra linhas */
-    word-break: break-word;  /* Quebra palavras grandes */
-    max-width: 400px;        /* Largura máxima para a célula */
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-width: 400px;  
 }


### PR DESCRIPTION
O HtmlDiff estava gerando uma tabela grande para exibir lado a lado as comparações, e como os textos longos estavam quebrando só no fim da linha, ai o navegador criava uma rolagem horizontal.

Usei .CSS para corrigir esse pequeno erro, assim ficando mais fácil a comparação entre as diferenças/semelhanças entre os textos.